### PR TITLE
Fix: no different style for jupyter lab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ __pycache__
 \#*#
 .#*
 .coverage
-src
+js/lib
 
 *.swp
 *.map

--- a/js/src/react-widget.js
+++ b/js/src/react-widget.js
@@ -3,27 +3,8 @@ import * as ReactDOM from 'react-dom';
 import * as _ from 'lodash';
 import { camelCase, snakeCase } from 'lodash';
 import * as widgets from '@jupyter-widgets/base';
+import {styleWrapper} from './style_wrap'
 
-// TODO: this part should be notebook only, since its fontsize is non-16
-// jupyter notebook (classical) fontfix
-import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
-import Typography from '@material-ui/core/Typography';
-
-const theme = createMuiTheme({
-    typography: {
-        // Tell Material-UI what the font-size on the html element is.
-        htmlFontSize: 10,
-        useNextVariants: true,
-    },
-});
-
-function FontSizeTheme(props) {
-    return (
-        <MuiThemeProvider theme={theme}>
-            <Typography component="span">{props.children}</Typography>
-        </MuiThemeProvider>
-    );
-}
 
 // TODO: move Material-UI specific parts (such as style) to subclass
 export
@@ -134,7 +115,7 @@ export
 
         react_render: function () {
             this.react_element = this.model.createWrappedReactElement({})
-            ReactDOM.render(<FontSizeTheme>{this.react_element}</FontSizeTheme>, this.root_element);
+            ReactDOM.render(styleWrapper(this.react_element), this.root_element);
             // this.app = this.model.createWrappedReactComponent()
             // ReactDOM.render(this.app, this.app_element);
         },

--- a/js/src/style_wrap.js
+++ b/js/src/style_wrap.js
@@ -1,0 +1,5 @@
+
+export 
+function styleWrapper(element) {
+    return element;
+}

--- a/js/src/style_wrap_notebook.js
+++ b/js/src/style_wrap_notebook.js
@@ -1,0 +1,25 @@
+// This is a specific 'fix' for the notebook only, since its fontsize is non-16
+import * as React from 'react';
+import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+
+const theme = createMuiTheme({
+    typography: {
+        // Tell Material-UI what the font-size on the html element is.
+        htmlFontSize: 10,
+        useNextVariants: true,
+    },
+});
+
+function FontSizeTheme(props) {
+    return (
+        <MuiThemeProvider theme={theme}>
+            <Typography component="span">{props.children}</Typography>
+        </MuiThemeProvider>
+    );
+}
+
+export 
+function styleWrapper(element) {
+    return <FontSizeTheme>{element}</FontSizeTheme>
+}

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -51,6 +51,9 @@ module.exports = [
         module: {
             rules: rules
         },
+        resolve: {
+            alias: {'./style_wrap': path.resolve(__dirname, 'src/style_wrap_notebook.js')},
+        },
         externals: ['@jupyter-widgets/base']
     },
     {// Embeddable jupyter-materialui bundle


### PR DESCRIPTION
cc @astrofrog @mariobuikhuizen
This will only wrap the element with the stylefix only for the classical notebook, using the `alias` option of webpack. Now jupyter lab renders correctly.